### PR TITLE
Implementation de l'ajout de parcelle par un utilisateur (non connecté)

### DIFF
--- a/app/Http/Controllers/Api/LandController.php
+++ b/app/Http/Controllers/Api/LandController.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\AddLandRequest;
+use App\Models\Land;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class LandController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(AddLandRequest $request)
+    {
+        /**
+         * je dois vérifier que l'utilisateur est connecté et qu'il a le rôle 'landOwner'
+         * je decommenterai le code une fois que l'auth sera terminée avec les rôles
+         */
+
+        /*
+        // Vérifier que l'utilisateur est connecté
+        $user = Auth::user();
+
+        if (!$user) {
+            return response()->json(['message' => 'Utilisateur non connecté.'], 401);
+        }
+
+        // Vérifier si l'utilisateur a le rôle 'landOwner'
+        if (!$user->hasRole('landOwner')) {
+            return response()->json(['message' => 'Accès interdit. Vous devez être un propriétaire de terre.'], 403);
+        }
+
+        // Vérifier si l'utilisateur existe bien
+        $userToCheck = User::find($request->user_id);
+        if (!$userToCheck) {
+            return response()->json(['message' => 'Utilisateur non trouvé.'], 404);
+        }*/
+
+        $data = $request->validated();
+
+        // Stockage avec nom unique
+        if ($request->hasFile('ownershipdoc')) {
+            $originalName = $request->file('ownershipdoc')->getClientOriginalName();
+            $filename = time() . '_' . uniqid() . '_' . $originalName;
+            $path = $request->file('ownershipdoc')->storeAs('documents', $filename, 'public');
+            $data['ownershipdoc'] = $path;
+        }
+
+        $parcelle = Land::create($data);
+
+        return response()->json([
+            'message' => 'Parcelle ajoutée avec succès.',
+            'data' => $parcelle
+        ], 201);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(string $id)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, string $id)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(string $id)
+    {
+        //
+    }
+}

--- a/app/Http/Requests/AddLandRequest.php
+++ b/app/Http/Requests/AddLandRequest.php
@@ -11,7 +11,7 @@ class AddLandRequest extends FormRequest
      */
     public function authorize(): bool
     {
-        return false;
+        return true;
     }
 
     /**
@@ -22,15 +22,30 @@ class AddLandRequest extends FormRequest
     public function rules(): array
     {
         return [
+            'user_id' => 'required|exists:users,id',
             'name' => 'required|string|max:50',
-            'date' => 'required|date',
             'city' => 'required|string|max:50',
-            'cultureType' => 'required|string|max:150',
             'area' => 'required|numeric|min:0',
-            'ownershipdoc' => 'required|file|mimes:pdf',
+            'cultureType' => 'required|string|max:150',
             'latitude' => 'required|numeric|between:-90,90',
             'longitude' => 'required|numeric|between:-180,180',
             'statut' => 'required|in:En culture,Récolte,En jachère',
+            'ownershipdoc' => [
+                'required',
+                'file',
+                'mimes:pdf',
+                'max:5120', // 5MB max
+                function ($attribute, $value, $fail) {
+                    if (request()->hasFile('ownershipdoc')) {
+                        $filename = request()->file('ownershipdoc')->getClientOriginalName();
+                        $exists = \App\Models\Land::where('ownershipdoc', 'like', "%$filename")->exists();
+
+                        if ($exists) {
+                            $fail("Un document avec ce nom existe déjà.");
+                        }
+                    }
+                }
+            ],
         ];
     }
 }

--- a/app/Http/Requests/AddLandRequest.php
+++ b/app/Http/Requests/AddLandRequest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class AddLandRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return false;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => 'required|string|max:50',
+            'date' => 'required|date',
+            'city' => 'required|string|max:50',
+            'cultureType' => 'required|string|max:150',
+            'area' => 'required|numeric|min:0',
+            'ownershipdoc' => 'required|file|mimes:pdf',
+            'latitude' => 'required|numeric|between:-90,90',
+            'longitude' => 'required|numeric|between:-180,180',
+            'statut' => 'required|in:En culture,Récolte,En jachère',
+        ];
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -14,4 +14,4 @@ Route::get('/user', function (Request $request) {
     return $request->user();
 })->middleware('auth:sanctum');
 
-Route::post('/parcelles', [LandController::class, 'store'])->withoutMiddleware('auth:api');
+Route::post('/lands', [LandController::class, 'store'])->withoutMiddleware('auth:api');

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Api\LandController;
 use App\Http\Controllers\Auth\AuthController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -12,3 +13,5 @@ Route::post('/register', [AuthController::class, 'register']);
 Route::get('/user', function (Request $request) {
     return $request->user();
 })->middleware('auth:sanctum');
+
+Route::post('/parcelles', [LandController::class, 'store'])->withoutMiddleware('auth:api');


### PR DESCRIPTION
un utilisateur peut à présent déclarer une parcelle, cependant dans le code il n'a pas besoin d'être connecté pour le faire. une fois que @Bouda-Bissari  finira complètement l'authentification, je pourrai modifier le code afin que l'utilisateur soit connecté et ait obligatoirement le rôle landOwner avant de déclarer une parcelle.