### PR TITLE
Consultation des interventions par les travailleurs

### DIFF
--- a/app/Http/Controllers/Api/InterventionController.php
+++ b/app/Http/Controllers/Api/InterventionController.php
@@ -14,9 +14,28 @@ class InterventionController extends Controller
     /**
      * Display a listing of the resource.
      */
-    public function index()
+    public function index() //Affiche la liste des interventions à faire aux travailleurs
     {
-        //
+        $user = Auth::user();
+
+        if (!$user) {
+            return response()->json(['message' => 'Utilisateur non connecté.'], 401);
+        }
+
+        if ($user->role !== 'worker') {
+            return response()->json(['message' => 'Accès interdit. Seuls les travailleurs peuvent voir les interventions à faire.'], 403);
+        }
+
+        $interventions = Intervention::where('isDone', false)->get();
+
+        if ($interventions->isEmpty()) {
+            return response()->json(['message' => 'Aucune intervention en attente trouvée.'], 404);
+        }
+
+        return response()->json([
+            'message' => 'Liste des interventions à faire récupérée avec succès.',
+            'data' => $interventions
+        ], 200);
     }
 
     /**

--- a/routes/api.php
+++ b/routes/api.php
@@ -30,4 +30,5 @@ Route::middleware(['auth:sanctum'])->group(function () {
      */
     Route::post('/intervention', [InterventionController::class, 'store']);
     Route::get('/myinterventions', [InterventionController::class, 'getInterventionsByUser']);
+    Route::get('/interventionstodo', [InterventionController::class, 'index']);
 });


### PR DESCRIPTION
les travailleurs peuvent désormais consulter les interventions non faites qui sont publiées par les propriétaires de terrains